### PR TITLE
Add options for parameters and input files

### DIFF
--- a/MOPSO.py
+++ b/MOPSO.py
@@ -56,7 +56,7 @@ class PSO:
         for i in range(self.num_iterations):
             write_csv('history/parameters/iteration' + str(i) + '.csv', [self.particles[i].position for i in range(self.num_particles)])
             validation_result = "history/validation/iteration" + str(i) + ".root"
-            subprocess.run(['cmsRun','reconstruction.py', "outputFileName=" + validation_result])
+            subprocess.run(['cmsRun','reconstruction.py', "inputFiles=file:step2.root", "parametersFile=parameters.csv", "outputFile=" + validation_result])
             for j, particle in enumerate(self.particles):
                 uproot_file = uproot.open(validation_result)
                 particle.evaluate_fitness(uproot_file, j)

--- a/reconstruction.py
+++ b/reconstruction.py
@@ -14,14 +14,14 @@ from Configuration.ProcessModifiers.gpu_cff import gpu
 from FWCore.ParameterSet.VarParsing import VarParsing
 
 # VarParsing instance
-options = VarParsing()
+options = VarParsing('analysis')
 
 # Custom options
-options.register ('outputFileName',
-              "output.root",
+options.register ('parametersFile',
+              "parameters.csv",
               VarParsing.multiplicity.singleton,
               VarParsing.varType.string,
-              "outputFileName")
+              "Name of parameters file")
 # options.register ('CAThetaCutForward',
 #               0.004,
 #               VarParsing.multiplicity.singleton,
@@ -63,7 +63,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:step2.root'),
+    fileNames = cms.untracked.vstring(options.inputFiles),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -119,12 +119,12 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
 process.FastTimerService.writeJSONSummary = cms.untracked.bool(True)
 process.FastTimerService.jsonFileName = cms.untracked.string('times.json')
-process.TFileService = cms.Service("TFileService", fileName = cms.string(options.outputFileName))
+process.TFileService = cms.Service("TFileService", fileName = cms.string(options.outputFile))
 
 
 # Create multiple reconstruction and validation objects with parameters in parameters.csv
 totalTasks = 0
-with open("parameters.csv", "r") as f:
+with open(options.parametersFile, "r") as f:
     csv_reader = reader(f)
     for i, row in enumerate(csv_reader):
         totalTasks += 1


### PR DESCRIPTION
Add the parametersFile custom option. Type string to support .csv files Use default inputFiles and outputFile option from VarParsing('analysis')

To run:
`cmsRun reconstruction.py inputFiles=file:step2.root parametersFile=parameters.csv outputFile=output.root`